### PR TITLE
Issue 17: Call to a member function bundle() on null

### DIFF
--- a/layout_wildcard.module
+++ b/layout_wildcard.module
@@ -109,6 +109,7 @@ function layout_wildcard_get_layout_by_path($path = NULL, $router_item = NULL) {
     foreach ($layouts as $layout) {
       // Contexts must be set before the layout's access may be checked.
       $contexts = $layout->getContexts();
+      $bad_context = FALSE;
       foreach ($contexts as $context) {
         if (isset($context->position)) {
 
@@ -129,13 +130,23 @@ function layout_wildcard_get_layout_by_path($path = NULL, $router_item = NULL) {
                 // If no context is set, load one using the layout info.
                 $context_info = layout_get_context_info($context->plugin);
                 if (isset($context_info['load callback'])) {
-                  $context_data = call_user_func_array($context_info['load callback'], $router_item['original_map'][$context->position]);
+                  $context_data = call_user_func_array($context_info['load callback'], array($router_item['original_map'][$context->position]));
                   $context->setData($context_data);
                 }
               }
             }
           }
+          // If any context had a position variable but after attempting to set
+          // its data from the value in that position we ended up with no
+          // context data, then the value that was in the position was bad. So
+          // we shouldn't use this layout.
+          if (!$context->data) {
+            $bad_context = TRUE;
+          }
         }
+      }
+      if ($bad_context) {
+        continue;
       }
 
       if (!$layout->disabled && $layout->checkAccess()) {


### PR DESCRIPTION
Handle this situation that arises if a context can’t be set but ancestor matching provides a layout.

Fixes https://github.com/backdrop-contrib/layout_wildcard/issues/17.